### PR TITLE
Update i2c.go

### DIFF
--- a/soc/nxp/i2c/i2c.go
+++ b/soc/nxp/i2c/i2c.go
@@ -138,11 +138,11 @@ func (hw *I2C) Read(target uint8, addr uint32, alen int, size int) (buf []byte, 
 	}
 	defer hw.stop()
 
-	if alen > 0 {
-		if err = hw.txAddress(target, addr, alen); err != nil {
-			return
-		}
-
+	if err = hw.txAddress(target, addr, alen); err != nil {
+		return
+	}
+	
+	if alen >= 0 {
 		if err = hw.start(true); err != nil {
 			return
 		}


### PR DESCRIPTION
adjusted Read() to not transmit a restart condition if alen < 0, so a negative adress length disables registered I2C transfers and allows packet-oriented I2C